### PR TITLE
Bounce Immunity & Ball Collision Box Fix

### DIFF
--- a/EnttPong/src/systems/CollisionSystem.cpp
+++ b/EnttPong/src/systems/CollisionSystem.cpp
@@ -27,6 +27,13 @@ namespace ep
 		const PositionComponent& ballPos = registry.get<PositionComponent>(ball);
 		const SpriteComponent& ballSprite = registry.get<SpriteComponent>(ball);
 
+		// If the ball is bounce immune we can count down the ticks and return
+		if(ballTag.m_bounceImmune > 0 )
+		{
+			ballTag.m_bounceImmune--;
+			return;
+		}
+
 		const auto player = registry.attachee<PlayerTag>();
 		const PositionComponent& playerPos = registry.get<PositionComponent>(player);
 		const SpriteComponent& playerSprite = registry.get<SpriteComponent>(player);
@@ -36,7 +43,7 @@ namespace ep
 		const SpriteComponent& aiSprite = registry.get<SpriteComponent>(ai);
 
 		// Ball bounding box.
-		SDL_Rect BallBB{ static_cast<int>(ballPos.m_x), static_cast<int>(ballPos.m_y), ballSprite.m_radius, ballSprite.m_radius };
+		SDL_Rect BallBB{ static_cast<int>(ballPos.m_x - ballSprite.m_radius), static_cast<int>(ballPos.m_y - ballSprite.m_radius), ballSprite.m_radius * 2, ballSprite.m_radius * 2};
 
 		// Player bounding box.
 		SDL_Rect PlayerBB{ static_cast<int>(playerPos.m_x), static_cast<int>(playerPos.m_y), playerSprite.m_width, playerSprite.m_height };
@@ -49,12 +56,18 @@ namespace ep
 		{
 			// Reverse ball, "bouncing" it.
 			ballTag.m_velX *= -1;
+
+			// Set bounce immunity for a few ticks to prevent ball from getting stuck inside the paddle
+			ballTag.m_bounceImmune = 5;
 		}
 		
 		if (SDL_HasIntersection(&AIBB, &BallBB) == SDL_TRUE)
 		{
 			// Reverse ball, "bouncing" it.
 			ballTag.m_velX *= -1;
+
+			// Set bounce immunity for a few ticks to prevent ball from getting stuck inside the paddle
+			ballTag.m_bounceImmune = 5;
 		}
 	}
 }

--- a/EnttPong/src/tags/BallTag.hpp
+++ b/EnttPong/src/tags/BallTag.hpp
@@ -56,6 +56,12 @@ namespace ep
 		/// The original Y velocity of the ball.
 		///
 		const double m_startingVelY;
+
+		///
+		/// The number of ticks the ball is bounce immune for
+		///
+		int m_bounceImmune;
+
 	};
 }
 


### PR DESCRIPTION
Noticed often times the ball was getting stuck in the paddles and bouncing through; fixed this by temporarily bypassing collision detection for an adjustable number of frames after the ball collides with a paddle. 

Also fixed a bug where the collision box for the ball was being created from the center point to the bottom right corner thereby making it easy for the top of the ball to pass through a paddle. 